### PR TITLE
Include cstdint to build with GCC 13

### DIFF
--- a/profiler/src/ProfilerImpl.hh
+++ b/profiler/src/ProfilerImpl.hh
@@ -19,6 +19,7 @@
 #define GZ_COMMON_PROFILERIMPL_HH_
 
 #include <string>
+#include <cstdint>
 
 namespace ignition
 {


### PR DESCRIPTION
This adds a missing cstdint include, allowing to build with GCC 13.
This can (and should) be ported to newer versions.